### PR TITLE
Update the API re `PostMessageOptions` vs `StructuredSerializeOptions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,11 @@ dictionary WindowPostMessageOptions : PostMessageOptions {
   USVString targetOrigin = "/";
 };
 
-dictionary PostMessageOptions {
-  sequence<object> transfer = [];
-  boolean includeUserActivation = false;
+// Note that this reintroduces a dictionary named `PostMessageOptions`, which
+// was renamed to `StructuredSerializeOptions` in
+// https://github.com/whatwg/html/pull/3414
+dictionary PostMessageOptions : StructuredSerializeOptions {
+    boolean includeUserActivation = false;
 };
 
 partial interface Window {
@@ -154,5 +156,8 @@ partial interface Worker {
 partial interface MessagePort {
  void postMessage(any message, PostMessageOptions options);
 };
+
+// Note that structuredClone in the WindowOrWorkerGlobalScope interface still
+// takes StructuredSerializeOptions, not PostMessageOptions
 
 ```


### PR DESCRIPTION
whatwg/html#3414 introduced the `structuredClone()` API and renamed the `PostMessageOptions` dictionary to `StructuredSerializeOptions`. When implementing this change in Chromium (https://chromium-review.googlesource.com/c/chromium/src/+/3245334), it was decided that, since `structuredClone()` has no use for the `includeUserActivation` parameter, it was better to keep the `StructuredSerializeOptions` as per the spec and incorporate that parameter in a derived interface keeping the old name `PostMessageOptions`.

This change updates the proposed IDL of the explainer to reflect these changes.